### PR TITLE
Fix crash on deploying assets to Facebook when response is not valid JSON

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,7 +36,13 @@ function deploytoFacebook(accestoken, appid, file, comment = "") {
                 console.log(err);
                 reject(err);
             }
-            const parsedBody = JSON.parse(body);
+            let parsedBody;
+            try {
+                parsedBody = JSON.parse(body);
+            } catch (e) {
+                console.error("Failed to parse Facebook deploy response: response is not valid JSON: ", e +  `: ${body}`);
+                return reject();
+            }
             if (parsedBody.success) {
                 console.log("File deployed to Facebook!");
                 resolve();


### PR DESCRIPTION
We're currently facing a crash in our internal pipelines coming from this package:
```sh
SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at Request._callback (<REDACTED>/node_modules/fbinstant-deploy/main.js:39:37)
    (...)
```

The actual JSON response isn't bubbling upstream, so we can't be sure of what is actually wrong.

This MR adds some basic error handling to the (attempt at) parsing the response from Facebook.